### PR TITLE
added disconnect_with lambda so that we do not leak connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_stalk (0.0.9)
+    easy_stalk (0.0.10)
       beaneater (~> 1.0)
       ezpool (~> 1.0)
       interactor (~> 3.1)

--- a/lib/easy_stalk/client.rb
+++ b/lib/easy_stalk/client.rb
@@ -20,9 +20,9 @@ module EasyStalk
       conns = config.beanstalkd_urls.shuffle
       i = 0
       # workers should only ever run a single thread to talk to beanstalk;
-      # set the pool size t "1" and the timeout low to ensure that we don't
+      # set the pool size to "1" and the timeout low to ensure that we don't
       # ever violate that
-      instance = EzPool.new(size: 1, timeout: 1, max_age: config.worker_reconnect_seconds) do
+      instance = EzPool.new(size: 1, timeout: 1, max_age: config.worker_reconnect_seconds, disconnect_with: lambda{ |client| client.close }) do
         # rotate through the connections fairly
         client = Beaneater.new(conns[i])
         i = (i + 1) % conns.length


### PR DESCRIPTION
Previously, we were not setting a `disconnect_with` value on the Worker EzPool instance, so when jobs were recycled the connection was leaked. Adding the `disconnect_with` lambda to explicitly close the connection seems to fix the issue.

this is re: https://phab.easypo.net/T1976