### PR TITLE
shut down workers after a certain number of jobs

### DIFF
--- a/lib/easy_stalk/configuration.rb
+++ b/lib/easy_stalk/configuration.rb
@@ -55,7 +55,7 @@ module EasyStalk
           self.worker_shutdown_after_jobs = DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS
         end
       else
-        self.shutdown_after_jobs = DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS
+        self.worker_shutdown_after_jobs = DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS
       end
     end
 

--- a/lib/easy_stalk/configuration.rb
+++ b/lib/easy_stalk/configuration.rb
@@ -137,7 +137,7 @@ module EasyStalk
       end
     end
 
-    def worker_shutdown_after_jobs(jobs)
+    def worker_shutdown_after_jobs=(jobs)
       if jobs.is_a? Range
         @worker_shutdown_after_jobs = jobs
       else

--- a/lib/easy_stalk/configuration.rb
+++ b/lib/easy_stalk/configuration.rb
@@ -48,9 +48,9 @@ module EasyStalk
 
       if ENV['BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS']
         if /^(\d+)\s*-\s*(\d+)$/.match(ENV['BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS'])
-          self.worker_shutdown_after_jobs = Range($1, $2)
+          self.worker_shutdown_after_jobs = Range.new($1.to_i, $2.to_i)
         elsif /^(\d+)$/.match(ENV['BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS'])
-          self.worker_shutdown_after_jobs = Range($1, $1)
+          self.worker_shutdown_after_jobs = Range.new($1.to_i, $1.to_i)
         else
           logger.warn "Invalid worker_shutdown_after_jobs #{ENV['BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS']}. Using default."
           self.worker_shutdown_after_jobs = DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS
@@ -141,6 +141,8 @@ module EasyStalk
     def worker_shutdown_after_jobs=(jobs)
       if jobs.is_a? Range
         @worker_shutdown_after_jobs = jobs
+      elsif jobs.respond_to?(:to_i)
+        @worker_shutdown_after_jobs = Range.new(jobs.to_i, jobs.to_i)
       else
         logger.warn "Invalid worker_shutdown_after_jobs #{jobs}. Using default."
         @worker_shutdown_after_jobs = DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS

--- a/lib/easy_stalk/configuration.rb
+++ b/lib/easy_stalk/configuration.rb
@@ -11,7 +11,8 @@ module EasyStalk
                 :beanstalkd_urls,
                 :pool_size,
                 :timeout_seconds,
-                :worker_reconnect_seconds
+                :worker_reconnect_seconds,
+                :worker_shutdown_after_jobs
 
     DEFAULT_POOL_SIZE = 5
     DEFAULT_TIMEOUT_SECONDS = 10

--- a/lib/easy_stalk/worker.rb
+++ b/lib/easy_stalk/worker.rb
@@ -29,6 +29,7 @@ module EasyStalk
       shutdown_after_jobs = EasyStalk.configuration.worker_shutdown_after_jobs
       if shutdown_after_jobs.end > 0
         shutdown_after_jobs = rand shutdown_after_jobs
+        EasyStalk.logger.info "Worker will automatically shut down after #{shutdown_after_jobs} jobs"
       else
         shutdown_after_jobs = nil
       end
@@ -62,8 +63,9 @@ module EasyStalk
             job.delete
           end
         end
-        if !shutdown_after_jobs.nil? and n_processed > shutdown_after_jobs
-          @cancelled = true
+        if !shutdown_after_jobs.nil? and n_processed >= shutdown_after_jobs
+          EasyStalk.logger.info "Worker has processed #{n_processed} jobs and is now shutting down"
+          cleanup
         end
       end
 

--- a/spec/lib/easy_stalk/configuration_spec.rb
+++ b/spec/lib/easy_stalk/configuration_spec.rb
@@ -206,6 +206,34 @@ describe EasyStalk::Configuration do
     end
   end
 
+  describe "#worker_shutdown_after_jobs" do
+    specify "gets default if not provided" do
+      expect(subject.worker_shutdown_after_jobs).to eq described_class::DEFAULT_WORKER_SHUTDOWN_AFTER_JOBS
+    end
+    specify "gets env if set to range" do
+      stub_const "ENV", {"BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS" => "1-3"}
+      expect(subject.worker_shutdown_after_jobs).to eq 1..3
+    end
+    specify "gets env if set to value" do
+      stub_const "ENV", {"BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS" => "100"}
+      expect(subject.worker_shutdown_after_jobs).to eq 100..100
+    end
+  end
+  describe "#worker_shutdown_after_jobs=" do
+    specify "takes ranges" do
+      subject.worker_shutdown_after_jobs = 1..10
+      expect(subject.worker_shutdown_after_jobs).to eq 1..10
+    end
+    specify "takes ints" do
+      subject.worker_shutdown_after_jobs = 1000
+      expect(subject.worker_shutdown_after_jobs).to eq 1000..1000
+    end
+    specify "falls back to defaults if given garbage" do
+      subject.worker_shutdown_after_jobs = {}
+      expect(subject.worker_shutdown_after_jobs).to eq 0..0
+    end
+  end
+
 end
 =begin
 


### PR DESCRIPTION
so that they can be restarted by the process supervisor

If `$BEANSTALKD_WORKER_SHUTDOWN_AFTER_JOBS` contains a range like `10-20`, every worker will shut down after some number of jobs randomly selected from that range. If it's just a single number, workers will shut down after that number of jobs. If it's either `0` or `0-0`, workers will never shut down (current behavior).