### PR TITLE
Update Gemfile.lock to include the new descendants_tracker gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     easy_stalk (0.1.2)
       beaneater (~> 1.0)
+      descendants_tracker (~> 0.0.4)
       ezpool (~> 1.0)
       interactor (~> 3.1)
 
@@ -10,9 +11,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     beaneater (1.0.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     ezpool (1.0.0)
-    interactor (3.1.0)
+    interactor (3.1.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -26,6 +29,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    thread_safe (0.3.6)
 
 PLATFORMS
   ruby
@@ -36,4 +40,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/spec/lib/easy_stalk/worker_spec.rb
+++ b/spec/lib/easy_stalk/worker_spec.rb
@@ -232,8 +232,9 @@ describe EasyStalk::Worker do
       end
 
       specify "buries the job after retry_times attempts" do
-        EasyStalk.configuration.default_worker_on_fail = Proc.new {}
+        expect(EasyStalk::Job).to receive(:descendants).and_return([ValidJob]).once
         expect(EasyStalk.logger).to receive(:info).at_least(2).times {}
+        EasyStalk.configuration.default_worker_on_fail = Proc.new {}
         beanstalk = EasyStalk::MockBeaneater.new
         mocked_client = EzPool.new(size: 2, timeout: 30) { beanstalk }
         tubes = EasyStalk::MockBeaneater::Tubes.new


### PR DESCRIPTION
Also fixes the flaky test @ https://github.com/EasyPost/easy_stalk/blob/master/spec/lib/easy_stalk/worker_spec.rb#L234