### PR TITLE
point build status link at travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyStalk
 
-[![Build Status](https://travis-ci.org/EasyPost/easy_stalk.svg?branch=master)](https://travis-ci.org/EasyPost/easy_stalk)
+[![Build Status](https://travis-ci.com/EasyPost/easy_stalk.svg?branch=master)](https://travis-ci.com/EasyPost/easy_stalk)
 
 A simple beanstalkd client for ruby
 


### PR DESCRIPTION
I'm migrating everything to the new infrastructure.